### PR TITLE
Added conftest.py for setup/teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from selenium import webdriver
+
+def pytest_addoption(parser):
+    parser.addoption("--browser", action="store", help="what browser to use")
+
+@pytest.fixture(scope='session')
+def driver(request):
+    browser_type = request.config.getoption('--browser')
+    if browser_type == "Firefox" or browser_type == "firefox":
+        driver = webdriver.Firefox()
+    elif browser_type == "Chrome" or browser_type == "chrome":
+        driver =  webdriver.Chrome()
+    else:
+        raise ValueError(f"Browser type {browser_type} not supported, choose Firefox or Chrome.")
+    
+    yield driver
+
+    driver.close()
+    


### PR DESCRIPTION
This makes it so the user can pass in the browser type to run the test cases on using "--browser Firefox" or "--browser Chrome".
Test cases can then pull the driver fixture and it will automatically create a webdriver object and close it on test exit.